### PR TITLE
fix the "forking projects" hyperlink in the last

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,4 +6,4 @@ Creating a *fork* is producing a personal copy of someone else's project. Forks 
 
 After forking this repository, you can make some changes to the project, and submit [a Pull Request](https://github.com/octocat/Spoon-Knife/pulls) as practice.
 
-For some more information on how to fork a repository, [check out our guide, "Forking Projects""](http://guides.github.com/overviews/forking/). Thanks! :sparkling_heart:
+For some more information on how to fork a repository, [check out our guide, "Forking Projects""](https://docs.github.com/en/get-started/quickstart/fork-a-repo). Thanks! :sparkling_heart:


### PR DESCRIPTION
The original link is obsolete, so update the latest official help doc link.